### PR TITLE
Fix: pending and fail methods not available on the callback.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -64,9 +64,11 @@ module.exports = function (options) {
       output.on();
       var args = Array.prototype.slice.call(arguments);
       var originalCallback = args[args.length - 1];
-      originalCallback.pending = output.off(originalCallback.pending);
-      originalCallback.fail = output.off(originalCallback.fail);
+      var pending = output.off(originalCallback.pending);
+      var fail = output.off(originalCallback.fail);
       args[args.length - 1] = output.off(originalCallback);
+      args[args.length - 1].pending = pending;
+      args[args.length - 1].fail = fail;
       fn.apply(this, args);
     });
   };


### PR DESCRIPTION
Hey,

The pending and fail callbacks were being removed by the wrapping of the original callback. This sets things straight.

By the way man, this plugin is just great. Exactly what I was looking for!
